### PR TITLE
Addresses Issue #36

### DIFF
--- a/cas_in_gb.pl
+++ b/cas_in_gb.pl
@@ -11,8 +11,8 @@ my $curr_taxonomy = "";
 my $curr_location = "";
 
 while (my $line = readline GB_FH) {
-	if ($line =~ m/^\s+(ORGANISM\s+.+)$/) {
 		print "$1\n";
+	if ($line =~ m/^\s*(ORGANISM\s+.+)$/) {
 		$curr_taxonomy = "TAXONOMY ";
 	} elsif (($line !~ m/^ {12}\S/) && ($curr_taxonomy ne "")) {
 		print "$curr_taxonomy\n";

--- a/cas_in_gb.pl
+++ b/cas_in_gb.pl
@@ -6,14 +6,16 @@ open GB_FH, "<", $gbfile;
 
 my $line = readline GB_FH;
 
-my $in_organism = "";
+my $accession = "";
 my $curr_taxonomy = "";
 my $curr_location = "";
 
 while (my $line = readline GB_FH) {
-		print "$1\n";
 	if ($line =~ m/^\s*(ORGANISM\s+.+)$/) {
+		print "$1\n$accession\n";
 		$curr_taxonomy = "TAXONOMY ";
+	} elsif ($line =~ m/^\s*(ACCESSION\s+.+)$/) {
+		$accession = "$1";
 	} elsif (($line !~ m/^ {12}\S/) && ($curr_taxonomy ne "")) {
 		print "$curr_taxonomy\n";
 		$curr_taxonomy = "";

--- a/cas_in_gb.pl
+++ b/cas_in_gb.pl
@@ -8,6 +8,7 @@ my $line = readline GB_FH;
 
 my $in_organism = "";
 my $curr_taxonomy = "";
+my $curr_location = "";
 
 while (my $line = readline GB_FH) {
 	if ($line =~ m/^\s+(ORGANISM\s+.+)$/) {
@@ -22,6 +23,9 @@ while (my $line = readline GB_FH) {
 		$line =~ s/\n//;
 		$curr_taxonomy .= $line;
 	} elsif ($line =~ m/^\s+\/(product=.*Cas.*)$/) {
-		print "$1\n";
+		print "$1\t$curr_location\n";
+		$curr_location = "";
+	} elsif ($line =~ m/^\s+CDS\s+(.*)$/) {
+		$curr_location = $1;
 	}
 }

--- a/cas_in_gb.pl
+++ b/cas_in_gb.pl
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+
+my $gbfile = shift @ARGV;
+
+open GB_FH, "<", $gbfile;
+
+my $line = readline GB_FH;
+
+my $in_organism = "";
+my $curr_taxonomy = "";
+
+while (my $line = readline GB_FH) {
+	if ($line =~ m/^\s+(ORGANISM\s+.+)$/) {
+		print "$1\n";
+		$curr_taxonomy = "TAXONOMY ";
+	} elsif (($line !~ m/^ {12}\S/) && ($curr_taxonomy ne "")) {
+		print "$curr_taxonomy\n";
+		$curr_taxonomy = "";
+	} elsif ($curr_taxonomy ne "") {
+		# we are still in the taxonomy line; concat.
+		$line =~ s/\s//g;
+		$line =~ s/\n//;
+		$curr_taxonomy .= $line;
+	} elsif ($line =~ m/^\s+\/(product=.*Cas.*)$/) {
+		print "$1\n";
+	}
+}


### PR DESCRIPTION
This should deal with the first part of issue #36 

```
$ perl cas_in_gb.pl /Users/daisie/Documents/Work/Sandbox/phageParser/data/NC_015138_genbank.txt 
ORGANISM  Acidovorax avenae subsp. avenae ATCC 19860
TAXONOMY Bacteria;Proteobacteria;Betaproteobacteria;Burkholderiales;Comamonadaceae;Acidovorax.
product="CRISPR-associated protein Cas1"
product="CRISPR-associated endonuclease Cas2"
product="CRISPR-associated protein Cas3"
product="CRISPR-associated protein Cas4"
product="CRISPR-associated protein Cas1"
product="CRISPR-associated endonuclease Cas2"
```